### PR TITLE
Fix for no docker command

### DIFF
--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -45,8 +45,9 @@ ExecStartPre=-/usr/bin/<%= @docker_command %> kill <%= @sanitised_title %>
 ExecStart=/usr/bin/<%= @docker_command %> run \
         <%= @docker_run_flags %> \
         --name <%= @sanitised_title %> \
-        <%= @image %> \
-        <% if @command %> <%= @command %><% end %>
+        <%= @image %> <% if @command %> \
+         <%= @command %>
+        <% end %>
 <% else %>
 ExecStart=/usr/bin/<%= @docker_command %> start -a <%= @sanitised_title %>
 <% end -%>


### PR DESCRIPTION
Corrects docker::run systemd behavior when no command is needed, such as https://github.com/google/cadvisor/blob/master/docs/running.md#with-docker